### PR TITLE
62 feature connect dashboard stats to real game data

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -121,6 +121,29 @@ def api_leaderboard():
 def dashboard():
     return render_template("dashboard.html")
 
+@app.route("/api/dashboard-stats")
+@login_required
+def api_dashboard_stats():
+    from app.models import GameResult
+    
+    recent_games = GameResult.query.filter_by(user_id=current_user.uid)\
+        .order_by(GameResult.timestamp.desc())\
+        .limit(5).all()
+    
+    total_games = GameResult.query.filter_by(user_id=current_user.uid).count()
+    
+    best = GameResult.query.filter_by(user_id=current_user.uid)\
+        .order_by(GameResult.score.desc()).first()
+    
+    return jsonify({
+        'total_games': total_games,
+        'best_score': best.score if best else None,
+        'recent_games': [{
+            'score': g.score,
+            'timestamp': g.timestamp.strftime('%d %b %Y')
+        } for g in recent_games]
+    })
+
 @app.route("/logout")
 def logout():
     logout_user()

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -1,4 +1,44 @@
 $(function () {
+    $.ajax({
+        url: '/api/dashboard-stats',
+        method: 'GET',
+        success: function (data) {
+            $('#totalGames').text(data.total_games || '0');
+            $('#bestScore').text(
+                data.best_score !== null
+                    ? data.best_score.toLocaleString() + ' pts'
+                    : '—'
+            );
+            
+            const container = $('#recentScores');
+            if (data.recent_games.length === 0) {
+                container.html(`
+                    <div class="empty-state">
+                        <p class="text-muted-light">No games played yet.</p>
+                        <a href="/game" class="btn btn-outline-warning btn-sm bangers-font">
+                            Play your first game!
+                        </a>
+                    </div>
+                `);
+                return;
+            }
+
+            let html = '';
+            data.recent_games.forEach(function (g) {
+                html += `
+                    <div class="profile-stat mb-2">
+                        <span class="stat-label">${g.timestamp}</span>
+                        <span class="stat-value">${g.score.toLocaleString()} pts</span>
+                    </div>
+                `;
+            });
+            container.html(html);
+        },
+        error: function () {
+            $('#totalGames').text('—');
+            $('#bestScore').text('—');
+        }
+    });
     // Load friends list
     $.ajax({
         url: '/api/friends',


### PR DESCRIPTION
## Changes

### Backend
- Added /api/dashboard-stats endpoint that returns:
  - Total games played
  - Best score achieved
  - Last 5 games with score and date

### Frontend
- Updated dashboard.js to fetch and display real stats
- Total Games now shows actual game count
- Best Score now shows highest score achieved
- Recent Scores now shows last 5 games, most recent first
- Empty state still shows correctly for new users

## Testing
Play a game and check the dashboard to verify 
all three stats update correctly.(i have tested this on multiple accounts and it works flawlessly, not really an issue , but if u have already played some games it wont reflect in the account , only the games and scores played from after you merge this pr will be counted )