### PR TITLE
67 feature public profile page to view other players stats and info

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -6,7 +6,7 @@ from werkzeug.utils import secure_filename
 from flask_login import login_user, login_required, logout_user, current_user
 
 from app import app
-from app.models import User
+from app.models import Friendship, User
 from app.image_upload import extract_gps, convert_to_webp, add_photo_record
 
 from app.controllers import login_user_service, register_user, change_user_password, get_leaderboard_data, get_all_time_leaderboard_data, add_score, get_user_daily_stat, get_user_all_time_stat
@@ -155,11 +155,26 @@ def user_profile(username):
     recent_games = GameResult.query.filter_by(user_id=user.uid)\
         .order_by(GameResult.timestamp.desc()).limit(5).all()
 
+    friendship_status = None
+    if current_user.is_authenticated and current_user.uid != user.uid:
+        friendship = Friendship.query.filter(
+            ((Friendship.requester_id == current_user.uid) & (Friendship.receiver_id == user.uid)) |
+            ((Friendship.requester_id == user.uid) & (Friendship.receiver_id == current_user.uid))
+        ).first()
+        if friendship:
+            if friendship.status == 'accepted':
+                friendship_status = 'friends'
+            elif friendship.requester_id == current_user.uid:
+                friendship_status = 'sent'
+            else:
+                friendship_status = 'received'
+                
     return render_template("dashboard.html",
         profile_user=user,
         total_games=total_games,
         best_score=best.score if best else None,
-        recent_games=recent_games
+        recent_games=recent_games,
+        friendship_status=friendship_status
     )
 
 @app.route("/api/user-stats/<int:uid>")

--- a/app/routes.py
+++ b/app/routes.py
@@ -162,6 +162,26 @@ def user_profile(username):
         recent_games=recent_games
     )
 
+@app.route("/api/user-stats/<int:uid>")
+def api_user_stats(uid):
+    from app.models import GameResult
+    user = User.query.get_or_404(uid)
+    
+    recent_games = GameResult.query.filter_by(user_id=uid)\
+        .order_by(GameResult.timestamp.desc()).limit(5).all()
+    total_games = GameResult.query.filter_by(user_id=uid).count()
+    best = GameResult.query.filter_by(user_id=uid)\
+        .order_by(GameResult.score.desc()).first()
+    
+    return jsonify({
+        'total_games': total_games,
+        'best_score': best.score if best else None,
+        'recent_games': [{
+            'score': g.score,
+            'timestamp': g.timestamp.strftime('%d %b %Y')
+        } for g in recent_games]
+    })
+
 
 @app.route("/logout")
 def logout():

--- a/app/routes.py
+++ b/app/routes.py
@@ -144,6 +144,25 @@ def api_dashboard_stats():
         } for g in recent_games]
     })
 
+@app.route("/user/<username>")
+def user_profile(username):
+    from app.models import GameResult
+    user = User.query.filter_by(username=username).first_or_404()
+    
+    total_games = GameResult.query.filter_by(user_id=user.uid).count()
+    best = GameResult.query.filter_by(user_id=user.uid)\
+        .order_by(GameResult.score.desc()).first()
+    recent_games = GameResult.query.filter_by(user_id=user.uid)\
+        .order_by(GameResult.timestamp.desc()).limit(5).all()
+
+    return render_template("dashboard.html",
+        profile_user=user,
+        total_games=total_games,
+        best_score=best.score if best else None,
+        recent_games=recent_games
+    )
+
+
 @app.route("/logout")
 def logout():
     logout_user()

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -1,23 +1,27 @@
 $(function () {
+
+    // ── Dashboard Stats ───────────────────────────────────────────────
+    const statsUrl = IS_OWN_PROFILE
+        ? '/api/dashboard-stats'
+        : '/api/user-stats/' + VIEWED_UID;
+
     $.ajax({
-        url: '/api/dashboard-stats',
+        url: statsUrl,
         method: 'GET',
         success: function (data) {
             $('#totalGames').text(data.total_games || '0');
             $('#bestScore').text(
-                data.best_score !== null
+                data.best_score !== null && data.best_score !== undefined
                     ? data.best_score.toLocaleString() + ' pts'
                     : '—'
             );
-            
+
             const container = $('#recentScores');
-            if (data.recent_games.length === 0) {
+            if (!data.recent_games || data.recent_games.length === 0) {
                 container.html(`
                     <div class="empty-state">
                         <p class="text-muted-light">No games played yet.</p>
-                        <a href="/game" class="btn btn-outline-warning btn-sm bangers-font">
-                            Play your first game!
-                        </a>
+                        ${IS_OWN_PROFILE ? '<a href="/game" class="btn btn-outline-warning btn-sm bangers-font">Play your first game!</a>' : ''}
                     </div>
                 `);
                 return;
@@ -39,67 +43,98 @@ $(function () {
             $('#bestScore').text('—');
         }
     });
-    // Load friends list
-    $.ajax({
-        url: '/api/friends',
-        method: 'GET',
-        success: function (friends) {
-            const container = $('#friendsList');
-            if (friends.length === 0) {
-                container.html(`
-                    <div class="empty-state">
-                        <p class="text-muted-light">No friends added yet.</p>
-                        <a href="/" class="btn btn-outline-warning btn-sm bangers-font">
-                            Find Friends
-                        </a>
-                    </div>
-                `);
-                return;
-            }
 
-            let html = '';
-            friends.forEach(function (f) {
-                const initials = f.username.substring(0, 2).toUpperCase();
-                html += `
-                    <div class="profile-stat mb-2">
-                        <div class="d-flex align-items-center gap-2">
-                            <div class="avatar-circle" style="width:2rem;height:2rem;font-size:0.8rem;">
-                                ${initials}
-                            </div>
-                            <span class="stat-value">${f.username}</span>
+    // ── Friends List (own dashboard only) ─────────────────────────────
+    if (IS_OWN_PROFILE) {
+        $.ajax({
+            url: '/api/friends',
+            method: 'GET',
+            success: function (friends) {
+                const container = $('#friendsList');
+                if (friends.length === 0) {
+                    container.html(`
+                        <div class="empty-state">
+                            <p class="text-muted-light">No friends added yet.</p>
+                            <a href="/" class="btn btn-outline-warning btn-sm bangers-font">Find Friends</a>
                         </div>
-                        <span class="stat-label">${f.total_score ? f.total_score.toLocaleString() + ' pts' : '0 pts'}</span>
-                    </div>
-                `;
-            });
-            container.html(html);
-        },
-        error: function () {
-            $('#friendsList').html('<p class="text-muted-light small">Failed to load friends.</p>');
-        }
-    });
+                    `);
+                    return;
+                }
 
-    // Load friends leaderboard
-    $.ajax({
-        url: '/api/friends',
-        method: 'GET',
-        success: function (friends) {
-            // Add current user to the list
-            const everyone = [...friends, CURRENT_USER];
-            const sorted = everyone.sort((a, b) => (b.total_score || 0) - (a.total_score || 0));
+                let html = '';
+                friends.forEach(function (f) {
+                    const initials = f.username.substring(0, 2).toUpperCase();
+                    html += `
+                        <div class="profile-stat mb-2">
+                            <div class="d-flex align-items-center gap-2">
+                                <div class="avatar-circle" style="width:2rem;height:2rem;font-size:0.8rem;">
+                                    ${initials}
+                                </div>
+                                <a href="/user/${f.username}" class="stat-value" style="color:var(--text-light);text-decoration:none;">
+                                    ${f.username}
+                                </a>
+                            </div>
+                            <span class="stat-label">${f.total_score ? f.total_score.toLocaleString() + ' pts' : '0 pts'}</span>
+                        </div>
+                    `;
+                });
+                container.html(html);
+            },
+            error: function () {
+                $('#friendsList').html('<p class="text-muted-light small">Failed to load friends.</p>');
+            }
+        });
 
-            let html = '';
-            sorted.forEach(function (f, i) {
-                const isMe = f.username === CURRENT_USER.username;
-                html += `
-                    <tr ${isMe ? 'style="color: var(--golden);"' : ''}>
-                        <td><span class="fw-bold">#${i + 1}</span></td>
-                        <td>${f.username}${isMe ? ' (you)' : ''}</td>
-                        <td class="text-end">${f.total_score ? f.total_score.toLocaleString() : '0'} pts</td>
-                    </tr>
-                `;
-            });
-            $('table tbody').html(html);
-        }
+        // ── Friends Leaderboard ───────────────────────────────────────
+        $.ajax({
+            url: '/api/friends',
+            method: 'GET',
+            success: function (friends) {
+                const everyone = [...friends, CURRENT_USER];
+                const sorted = everyone.sort((a, b) => (b.total_score || 0) - (a.total_score || 0));
+
+                let html = '';
+                sorted.forEach(function (f, i) {
+                    const isMe = f.username === CURRENT_USER.username;
+                    const nameLink = isMe
+                        ? `${f.username} (you)`
+                        : `<a href="/user/${f.username}" style="color:inherit;text-decoration:none;">${f.username}</a>`;
+                    html += `
+                        <tr ${isMe ? 'style="color: var(--golden);"' : ''}>
+                            <td><span class="fw-bold">#${i + 1}</span></td>
+                            <td>${nameLink}</td>
+                            <td class="text-end">${f.total_score ? f.total_score.toLocaleString() : '0'} pts</td>
+                        </tr>
+                    `;
+                });
+                $('table tbody').html(html);
+            }
+        });
+    }
+
+    // ── Add Friend button (on other user's profile) ───────────────────
+    $('#add-friend-btn').on('click', function () {
+        const uid = $(this).data('uid');
+        const $btn = $(this);
+        $btn.prop('disabled', true).text('Sending...');
+
+        $.ajax({
+            url: '/api/friends/add',
+            method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({ uid: uid }),
+            success: function () {
+                $btn.text('Request Sent!').removeClass('btn-warning').addClass('btn-outline-warning');
+            },
+            error: function (xhr) {
+                const msg = xhr.responseJSON?.error || 'Something went wrong';
+                if (msg.includes('already exists')) {
+                    $btn.text('Already Friends').prop('disabled', true);
+                } else {
+                    $btn.prop('disabled', false).text('Add Friend');
+                    alert(msg);
+                }
+            }
+        });
     });
 });

--- a/app/static/js/friends.js
+++ b/app/static/js/friends.js
@@ -108,7 +108,7 @@ $(function () {
                         if (u.friendship_status === 'friends') {
                             btnHtml = '<span class="text-muted small">Friends</span>';
                         } else if (u.friendship_status === 'sent') {
-                            btnHtml = '<span class="text-muted small">Requested</span>';
+                            btnHtml = '<span class="badge" style="background:rgba(255,202,44,0.2);color:var(--golden);border:1px solid var(--golden);border-radius:0.5rem;padding:0.25rem 0.5rem;font-size:0.75rem;">⏳ Invite Sent</span>';
                         } else if (u.friendship_status === 'received') {
                             btnHtml = '<span class="text-muted small">Wants to add you</span>';
                         } else {

--- a/app/static/js/friends.js
+++ b/app/static/js/friends.js
@@ -21,7 +21,9 @@ $(function () {
                         <div class="friend-card">
                             <div class="friend-card__avatar">${initials}</div>
                             <div class="friend-card__meta">
-                                <div class="friend-card__name">${f.username}</div>
+                                <a href="/user/${f.username}" class="friend-card__name" style="color:var(--text-light);text-decoration:none;">
+                                    ${f.username}
+                                </a>
                                 <div class="friend-card__label">${f.total_score ? f.total_score.toLocaleString() + ' pts' : 'No score yet'}</div>
                             </div>
                         </div>
@@ -118,7 +120,7 @@ $(function () {
                             <div class="friend-card mt-2">
                                 <div class="friend-card__avatar">${initials}</div>
                                 <div class="friend-card__meta">
-                                    <div class="friend-card__name">${u.username}</div>
+                                    <a href="/user/${u.username}" class="friend-card__name" style="color:var(--text-light);text-decoration:none;">${u.username}</a>
                                     <div>${btnHtml}</div>
                                 </div>
                             </div>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -14,10 +14,10 @@
                 <div class="dashboard-welcome p-4">
                     <div class="d-flex align-items-center gap-4">
                         <div class="avatar-circle">
-                            <span>{{ current_user.username[0].upper() }}</span>
+                            <span>{{ viewed_user.username[0].upper() }}</span>
                         </div>
                         <div>
-                            <h1 class="orbitron-font mb-1">Welcome back, {{ current_user.username }}!</h1>
+                            <h1 class="orbitron-font mb-1">Welcome back, {{ viewed_user.username }}!</h1>
                             <p class="text-muted-light mb-0">Ready to explore UWA?</p>
                         </div>
                         <div class="ms-auto">
@@ -38,11 +38,11 @@
                     <h2 class="orbitron-font h5 mb-4 card-title-gold">Profile</h2>
                     <div class="profile-stat mb-3">
                         <span class="stat-label">Username</span>
-                        <span class="stat-value">{{ current_user.username }}</span>
+                        <span class="stat-value">{{ viewed_user.username }}</span>
                     </div>
                     <div class="profile-stat mb-3">
                         <span class="stat-label">Email</span>
-                        <span class="stat-value">{{ current_user.email }}</span>
+                        <span class="stat-value">{{ viewed_user.email }}</span>
                     </div>
                     <div class="profile-stat mb-3">
                         <span class="stat-label">Total Games</span>
@@ -123,8 +123,8 @@
 {% block scripts %}
 <script>
     const CURRENT_USER = {
-        username: "{{ current_user.username }}",
-        total_score: {{ current_user.total_score or 0 }}
+        username: "{{ viewed_user.username }}",
+        total_score: {{ viewed_user.total_score or 0 }}
     };
 </script>
 <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -34,10 +34,25 @@
                         <div class="ms-auto">
                             {% if profile_user is defined %}
                                 {% if current_user.is_authenticated and current_user.uid != viewed_user.uid %}
-                                <button id="add-friend-btn" class="btn btn-warning bangers-font"
-                                    data-uid="{{ viewed_user.uid }}">
-                                    Add Friend
-                                </button>
+                                    {% if friendship_status == 'friends' %}
+                                    <button class="btn btn-outline-warning bangers-font" disabled>
+                                        Already Friends
+                                    </button>
+                                    {% elif friendship_status == 'sent' %}
+                                    <button class="btn btn-outline-warning bangers-font" disabled>
+                                        ⏳ Invite Sent
+                                    </button>
+                                    {% elif friendship_status == 'received' %}
+                                    <button id="add-friend-btn" class="btn btn-warning bangers-font"
+                                        data-uid="{{ viewed_user.uid }}">
+                                        Accept Friend Request
+                                    </button>
+                                    {% else %}
+                                    <button id="add-friend-btn" class="btn btn-warning bangers-font"
+                                        data-uid="{{ viewed_user.uid }}">
+                                        Add Friend
+                                    </button>
+                                    {% endif %}
                                 {% endif %}
                             {% else %}
                             <a href="{{ url_for('game') }}" class="btn btn-warning btn-lg bangers-font">

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -23,8 +23,13 @@
                             <span>{{ viewed_user.username[0].upper() }}</span>
                         </div>
                         <div>
+                            {% if profile_user is defined %}
+                            <h1 class="orbitron-font mb-1">{{ viewed_user.username }}'s Profile</h1>
+                            <p class="text-muted-light mb-0">UWA Campus Explorer</p>
+                            {% else %}
                             <h1 class="orbitron-font mb-1">Welcome back, {{ viewed_user.username }}!</h1>
                             <p class="text-muted-light mb-0">Ready to explore UWA?</p>
+                            {% endif %}
                         </div>
                         <div class="ms-auto">
                             <a href="{{ url_for('game') }}" class="btn btn-warning btn-lg bangers-font">

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -32,9 +32,18 @@
                             {% endif %}
                         </div>
                         <div class="ms-auto">
+                            {% if profile_user is defined %}
+                                {% if current_user.is_authenticated and current_user.uid != viewed_user.uid %}
+                                <button id="add-friend-btn" class="btn btn-warning bangers-font"
+                                    data-uid="{{ viewed_user.uid }}">
+                                    Add Friend
+                                </button>
+                                {% endif %}
+                            {% else %}
                             <a href="{{ url_for('game') }}" class="btn btn-warning btn-lg bangers-font">
                                 Play Now
                             </a>
+                            {% endif %}
                         </div>
                     </div>
                 </div>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -60,10 +60,12 @@
                         <span class="stat-label">Username</span>
                         <span class="stat-value">{{ viewed_user.username }}</span>
                     </div>
+                    {% if profile_user is not defined %}
                     <div class="profile-stat mb-3">
                         <span class="stat-label">Email</span>
                         <span class="stat-value">{{ viewed_user.email }}</span>
                     </div>
+                    {% endif %}
                     <div class="profile-stat mb-3">
                         <span class="stat-label">Total Games</span>
                         <span class="stat-value" id="totalGames">—</span>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,11 +1,17 @@
 {% extends "base.html" %}
 
-{% block title %}Dashboard - UWAGuessr{% endblock %}
+{% block title %}
+    {% if profile_user is defined %}
+        {{ profile_user.username }} - UWAGuessr
+    {% else %}
+        Dashboard - UWAGuessr
+    {% endif %}
+{% endblock %}
 {% block body_class %}page-dashboard{% endblock %}
 
-{% block content %}
-
 {% set viewed_user = profile_user if profile_user is defined else current_user %}
+
+{% block content %}
 
 <section class="dashboard-hero-section d-flex align-items-center">
     <div class="container py-5">

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -189,6 +189,36 @@
 </script>
 <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 <script src="{{ url_for('static', filename='js/dashboard.js') }}"></script>
+{% if profile_user is defined and current_user.is_authenticated and current_user.uid != viewed_user.uid %}
+<script>
+$(function () {
+    $('#add-friend-btn').on('click', function () {
+        const uid = $(this).data('uid');
+        const $btn = $(this);
+        $btn.prop('disabled', true).text('Sending...');
+
+        $.ajax({
+            url: '/api/friends/add',
+            method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({ uid: uid }),
+            success: function () {
+                $btn.text('Request Sent!').removeClass('btn-warning').addClass('btn-outline-warning');
+            },
+            error: function (xhr) {
+                const msg = xhr.responseJSON?.error || 'Something went wrong';
+                if (msg.includes('already exists')) {
+                    $btn.text('Already Friends').prop('disabled', true);
+                } else {
+                    $btn.prop('disabled', false).text('Add Friend');
+                    alert(msg);
+                }
+            }
+        });
+    });
+});
+</script>
+{% endif %}
 {% endblock %}
 
 

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -115,6 +115,7 @@
             </div>
             
             <!-- friends list -->
+            {% if profile_user is not defined %}
             <div class="col-lg-4">  
                 <div class="dashboard-card h-100 p-4">
                     <h2 class="orbitron-font h5 mb-4 card-title-gold">Friends</h2>
@@ -128,8 +129,10 @@
                     </div>
                 </div>
             </div>
+            {% endif %}
             
         <!-- Leaderboard Preview -->
+            {% if profile_user is not defined %}
             <div class="col-12">
                 <div class="dashboard-card p-4">
                 <h2 class="orbitron-font h5 mb-4 card-title-gold">🏆 Friends Leaderboard</h2>
@@ -159,7 +162,20 @@
                     </div>
                 </div>
             </div>
+            {% endif %}
         </div>
+
+        {% if profile_user is defined %}
+        <div class="mt-4">
+            <a href="{{ url_for('leaderboard') }}" class="btn btn-outline-warning bangers-font">
+                View Leaderboard
+            </a>
+            <a href="{{ url_for('index') }}" class="btn btn-outline-light bangers-font ms-2">
+                Back to Home
+            </a>
+        </div>
+        {% endif %}
+
     </div>
 </section>
 
@@ -167,8 +183,8 @@
 {% block scripts %}
 <script>
     const CURRENT_USER = {
-        username: "{{ viewed_user.username }}",
-        total_score: {{ viewed_user.total_score or 0 }}
+        username: "{{ current_user.username if current_user.is_authenticated else '' }}",
+        total_score: {{ current_user.total_score if current_user.is_authenticated else 0 }}
     };
 </script>
 <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -68,7 +68,13 @@
                     {% endif %}
                     <div class="profile-stat mb-3">
                         <span class="stat-label">Total Games</span>
-                        <span class="stat-value" id="totalGames">—</span>
+                        <span class="stat-value" id="totalGames">
+                            {% if profile_user is defined %}
+                                {% if best_score %}{{ "{:,}".format(best_score) }} pts{% else %}—{% endif %}
+                            {% else %}
+                                —   
+                            {% endif %}
+                        </span>
                     </div>
                     <div class="profile-stat">
                         <span class="stat-label">Best Score</span>
@@ -82,12 +88,28 @@
                 <div class="dashboard-card h-100 p-4">
                     <h2 class="orbitron-font h5 mb-4 card-title-gold">Recent Scores</h2>
                     <div id="recentScores">
+                        {% if profile_user is defined %}
+                            {% if recent_scores %}
+                                    {% for score in recent_scores %}
+                                        <div class="profile-stat mb-2">
+                                            <span class="stat-label">{{ game.timestamp.strftime('%d %b %Y') }}</span>
+                                            <span class="stat-value">{{ "{:,}".format(game.score) }} pts</span>
+                                        </div>
+                                        {% endfor %}
+                                
+                            {% else %}
+                                <div class="empty-state">
+                                    <p class="text-muted-light">No games played yet.</p>
+                                </div>
+                            {% endif %}
+                        {% else %}
                         <div class="empty-state">
                             <p class="text-muted-light">No games played yet.</p>
                             <a href="{{ url_for('game') }}" class="btn btn-outline-warning btn-sm bangers-font">
                             Play your first game!
                             </a>
                         </div>
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -68,13 +68,7 @@
                     {% endif %}
                     <div class="profile-stat mb-3">
                         <span class="stat-label">Total Games</span>
-                        <span class="stat-value" id="totalGames">
-                            {% if profile_user is defined %}
-                                {% if best_score %}{{ "{:,}".format(best_score) }} pts{% else %}—{% endif %}
-                            {% else %}
-                                —   
-                            {% endif %}
-                        </span>
+                        <span class="stat-value" id="totalGames">—</span>
                     </div>
                     <div class="profile-stat">
                         <span class="stat-label">Best Score</span>
@@ -90,12 +84,12 @@
                     <div id="recentScores">
                         {% if profile_user is defined %}
                             {% if recent_scores %}
-                                    {% for score in recent_scores %}
+                                    {% for game in recent_games %}
                                         <div class="profile-stat mb-2">
                                             <span class="stat-label">{{ game.timestamp.strftime('%d %b %Y') }}</span>
                                             <span class="stat-value">{{ "{:,}".format(game.score) }} pts</span>
                                         </div>
-                                        {% endfor %}
+                                    {% endfor %}
                                 
                             {% else %}
                                 <div class="empty-state">
@@ -122,9 +116,6 @@
                     <div id="friendsList">
                         <div class="empty-state">
                             <p class="text-muted-light">No friends added yet.</p>
-                            <button class="btn btn-outline-warning btn-sm bangers-font" disabled>
-                                Coming Soon
-                            </button>
                         </div>
                     </div>
                 </div>
@@ -186,38 +177,12 @@
         username: "{{ current_user.username if current_user.is_authenticated else '' }}",
         total_score: {{ current_user.total_score if current_user.is_authenticated else 0 }}
     };
+    const VIEWED_UID = {{ viewed_user.uid }};
+    const IS_OWN_PROFILE = {{ 'true' if profile_user is not defined else 'false' }};
 </script>
 <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 <script src="{{ url_for('static', filename='js/dashboard.js') }}"></script>
 {% if profile_user is defined and current_user.is_authenticated and current_user.uid != viewed_user.uid %}
-<script>
-$(function () {
-    $('#add-friend-btn').on('click', function () {
-        const uid = $(this).data('uid');
-        const $btn = $(this);
-        $btn.prop('disabled', true).text('Sending...');
-
-        $.ajax({
-            url: '/api/friends/add',
-            method: 'POST',
-            contentType: 'application/json',
-            data: JSON.stringify({ uid: uid }),
-            success: function () {
-                $btn.text('Request Sent!').removeClass('btn-warning').addClass('btn-outline-warning');
-            },
-            error: function (xhr) {
-                const msg = xhr.responseJSON?.error || 'Something went wrong';
-                if (msg.includes('already exists')) {
-                    $btn.text('Already Friends').prop('disabled', true);
-                } else {
-                    $btn.prop('disabled', false).text('Add Friend');
-                    alert(msg);
-                }
-            }
-        });
-    });
-});
-</script>
 {% endif %}
 {% endblock %}
 

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -5,6 +5,8 @@
 
 {% block content %}
 
+{% set viewed_user = profile_user if profile_user is defined else current_user %}
+
 <section class="dashboard-hero-section d-flex align-items-center">
     <div class="container py-5">
         <div class="row mb-5">

--- a/app/templates/leaderboard.html
+++ b/app/templates/leaderboard.html
@@ -8,7 +8,9 @@
         {% if scores|length >= 1 %}
         <div class="rank-card rank-1">
             <div class="bangers-font rank-number" style="color: #ffd700;">#1</div>
-            <div class="fw-bold rank-name">{{ scores[0].username }}</div>
+            <div class="fw-bold rank-name">
+                <a href="/user/{{ scores[0].username }}" style="color:inherit;text-decoration:none;">{{ scores[0].username }}</a>
+            </div>
             <div class="text-muted rank-score">{{ "{:,}".format(scores[0].high_score) }} pts</div>
         </div>
         {% endif %}
@@ -16,7 +18,9 @@
         {% if scores|length >= 2 %}
         <div class="rank-card rank-2">
             <div class="bangers-font rank-number" style="color: #c0c0c0;">#2</div>
-            <div class="fw-bold rank-name">{{ scores[1].username }}</div>
+            <div class="fw-bold rank-name">
+                <a href="/user/{{ scores[1].username }}" style="color:inherit;text-decoration:none;">{{ scores[1].username }}</a>
+            </div>
             <div class="text-muted rank-score">{{ "{:,}".format(scores[1].high_score) }} pts</div>
         </div>
         {% endif %}
@@ -24,7 +28,9 @@
         {% if scores|length >= 3 %}
         <div class="rank-card rank-3">
             <div class="bangers-font rank-number" style="color: #cd7f32;">#3</div>
-            <div class="fw-bold rank-name">{{ scores[2].username }}</div>
+            <div class="fw-bold rank-name">
+                <a href="/user/{{ scores[2].username }}" style="color:inherit;text-decoration:none;">{{ scores[2].username }}</a>
+            </div>
             <div class="text-muted rank-score">{{ "{:,}".format(scores[2].high_score) }} pts</div>
         </div>
         {% endif %}
@@ -37,7 +43,9 @@
                 {% for score in scores[3:] %}
                 <tr>
                     <td class="ps-4 fw-bold row-rank">#{{ loop.index + 3 }}</td>
-                    <td class="fw-bold row-name" style="color: var(--golden);">{{ score.username }}</td>
+                    <td class="fw-bold row-name" style="color: var(--golden);">
+                        <a href="/user/{{ score.username }}" style="color:inherit;text-decoration:none;">{{ score.username }}</a>
+                    </td>
                     <td class="text-end pe-4 row-score">{{ "{:,}".format(score.high_score) }} pts</td>
                 </tr>
                 {% endfor %}
@@ -56,7 +64,9 @@
     <div class="sticky-user-row">
         <div class="container d-flex justify-content-between align-items-center">
             <div class="fw-bold fs-4">#{{ user_stat.rank }}</div>
-            <div class="fw-bold fs-4">{{ current_user.username }}</div>
+            <div class="fw-bold fs-4">
+                <a href="/user/{{ current_user.username }}" style="color:inherit;text-decoration:none;">{{ current_user.username }}</a>
+            </div>
             <div class="fw-bold fs-4">{{ "{:,}".format(user_stat.score) }} pts</div>
         </div>
     </div>


### PR DESCRIPTION
## Changes

### Backend
- Added /user/<username> route for public profile pages
- Added /api/user-stats/<uid> endpoint for fetching 
  any user's game stats
- Fixed friendship_status not being passed to template

### Frontend
- Reused dashboard.html for public profiles
- Profile shows username, total games, best score 
  and last 5 games
- Add Friend button shows correct state on page load:
  - "Add Friend" if no relationship
  - "Invite Sent" if request already sent
  - "Accept Friend Request" if they sent you one
  - "Already Friends" if already friends
- Usernames are now clickable in:
  - Friends sidebar
  - Dashboard friends list
  - Friends leaderboard
  - Global leaderboard (top 3 and table)
- Search results in friends sidebar show "⏳ Invite Sent" 
  badge instead of blank space for pending requests

## Testing
- Visit /user/<username> to view any user's profile
- Click usernames on leaderboard and friends list
- Check Add Friend button shows correct statew