### PR TITLE
fixed email request not sending csrf token

### DIFF
--- a/app/static/js/forgot_password.js
+++ b/app/static/js/forgot_password.js
@@ -86,6 +86,9 @@ $(function () {
       url: "/api/get-security-question",
       method: "POST",
       contentType: "application/json",
+      headers: {
+        "X-CSRFToken": $("input[name='csrf_token']").val(),
+      },
       data: JSON.stringify({ email }),
       success: function (response) {
         $("#securityQuestionText").text(response.securityQuestion);


### PR DESCRIPTION
Forgot password was only sending a CSRF token for one of its forms, despite having two forms. This is fixed.